### PR TITLE
Added missing space in email template

### DIFF
--- a/src/class.cscf_contact.php
+++ b/src/class.cscf_contact.php
@@ -161,7 +161,9 @@ class cscf_Contact {
 		$message .= esc_html__( 'Email: ', 'clean-and-simple-contact-form-by-meg-nicholas' ) . esc_attr( $this->Email ) . "\n\n";
 		$message .= esc_html__( 'Page URL: ', 'clean-and-simple-contact-form-by-meg-nicholas' ) . get_permalink( $this->PostID ) . "\n\n";
 		$message .= esc_html__( 'Message:', 'clean-and-simple-contact-form-by-meg-nicholas' ) . "\n\n" . esc_html( $this->Message ) . "\n\n";
-		$message .= cscf_PluginSettings::ContactConsentMsg() . ': ' . ( $this->ContactConsent ? esc_html__( 'yes', 'clean-and-simple-contact-form-by-meg-nicholas' ) : esc_html__( 'no', 'clean-and-simple-contact-form-by-meg-nicholas' ) );
+		if ( cscf_PluginSettings::ContactConsent() ) {
+			$message .= cscf_PluginSettings::ContactConsentMsg() . ': ' . ( $this->ContactConsent ? esc_html__( 'yes', 'clean-and-simple-contact-form-by-meg-nicholas' ) : esc_html__( 'no', 'clean-and-simple-contact-form-by-meg-nicholas' ) );
+		}
 
 
 		$result = ( wp_mail( cscf_PluginSettings::RecipientEmails(), cscf_PluginSettings::Subject(), stripslashes( $message ), $header ) );

--- a/src/class.cscf_contact.php
+++ b/src/class.cscf_contact.php
@@ -157,10 +157,10 @@ class cscf_Contact {
 		$header = "Content-Type: text/plain\r\nReply-To: " . $this->Email . "\r\n";
 
 		//message
-		$message = esc_html__( 'From: ', 'clean-and-simple-contact-form-by-meg-nicholas' ) . esc_attr( $this->Name ) . "\n\n";
-		$message .= esc_html__( 'Email: ', 'clean-and-simple-contact-form-by-meg-nicholas' ) . esc_attr( $this->Email ) . "\n\n";
-		$message .= esc_html__( 'Page URL: ', 'clean-and-simple-contact-form-by-meg-nicholas' ) . get_permalink( $this->PostID ) . "\n\n";
-		$message .= esc_html__( 'Message:', 'clean-and-simple-contact-form-by-meg-nicholas' ) . "\n\n" . esc_html( $this->Message ) . "\n\n";
+		$message = esc_html__( 'From', 'clean-and-simple-contact-form-by-meg-nicholas' ) . ': ' . esc_attr( $this->Name ) . "\n\n";
+		$message .= esc_html__( 'Email', 'clean-and-simple-contact-form-by-meg-nicholas' ) . ': ' . esc_attr( $this->Email ) . "\n\n";
+		$message .= esc_html__( 'Page URL', 'clean-and-simple-contact-form-by-meg-nicholas' ) . ': ' . get_permalink( $this->PostID ) . "\n\n";
+		$message .= esc_html__( 'Message', 'clean-and-simple-contact-form-by-meg-nicholas' ) . ':\n\n" . esc_html( $this->Message ) . "\n\n";
 		$message .= cscf_PluginSettings::ContactConsentMsg() . ': ' . ( $this->ContactConsent ? esc_html__( 'yes', 'clean-and-simple-contact-form-by-meg-nicholas' ) : esc_html__( 'no', 'clean-and-simple-contact-form-by-meg-nicholas' ) );
 
 

--- a/src/class.cscf_contact.php
+++ b/src/class.cscf_contact.php
@@ -11,6 +11,7 @@ class cscf_Contact {
 	var $Message;
 	var $EmailToSender;
 	var $ErrorMessage;
+	var $PhoneNumber;
 	var $ContactConsent;
 	var $RecaptchaPublicKey;
 	var $RecaptchaPrivateKey;
@@ -45,6 +46,11 @@ class cscf_Contact {
 							break;
 						case 'message':
 							$this->Message = sanitize_textarea_field( $value );
+							break;
+						case 'phone-number':
+							if ( cscf_PluginSettings::PhoneNumber() ) {
+								$this->PhoneNumber = sanitize_text_field( $value );
+							}
 							break;
 						case 'contact-consent':
 							if ( cscf_PluginSettings::ContactConsent() ) {
@@ -113,6 +119,13 @@ class cscf_Contact {
 			$this->Errors['email'] = esc_html__( 'Please enter a valid email address.', 'clean-and-simple-contact-form-by-meg-nicholas' );
 		}
 
+		//mandatory phone number
+		if ( cscf_PluginSettings::PhoneNumber() && cscf_PluginSettings::PhoneNumberMandatory() ) {
+			if ( strlen( $this->PhoneNumber ) == 0 ) {
+				$this->Errors['confirm-email'] = esc_html__( 'Please give your phone number.', 'clean-and-simple-contact-form-by-meg-nicholas' );
+			}
+		}
+
 		//contact consent
 		if ( cscf_PluginSettings::ContactConsent() ) {
 			if ( ! $this->ContactConsent ) {
@@ -159,9 +172,14 @@ class cscf_Contact {
 		//message
 		$message = esc_html__( 'From: ', 'clean-and-simple-contact-form-by-meg-nicholas' ) . esc_attr( $this->Name ) . "\n\n";
 		$message .= esc_html__( 'Email: ', 'clean-and-simple-contact-form-by-meg-nicholas' ) . esc_attr( $this->Email ) . "\n\n";
+		if ( cscf_PluginSettings::PhoneNumber() ) {
+			$message .= esc_html__( 'Phone: ', 'clean-and-simple-contact-form-by-meg-nicholas' ) . esc_attr( $this->PhoneNumber ) . "\n\n";
+		}
 		$message .= esc_html__( 'Page URL: ', 'clean-and-simple-contact-form-by-meg-nicholas' ) . get_permalink( $this->PostID ) . "\n\n";
 		$message .= esc_html__( 'Message:', 'clean-and-simple-contact-form-by-meg-nicholas' ) . "\n\n" . esc_html( $this->Message ) . "\n\n";
-		$message .= cscf_PluginSettings::ContactConsentMsg() . ': ' . ( $this->ContactConsent ? esc_html__( 'yes', 'clean-and-simple-contact-form-by-meg-nicholas' ) : esc_html__( 'no', 'clean-and-simple-contact-form-by-meg-nicholas' ) );
+		if ( cscf_PluginSettings::ContactConsent() ) {
+			$message .= cscf_PluginSettings::ContactConsentMsg() . ': ' . ( $this->ContactConsent ? esc_html__( 'yes', 'clean-and-simple-contact-form-by-meg-nicholas' ) : esc_html__( 'no', 'clean-and-simple-contact-form-by-meg-nicholas' ) );
+		}
 
 
 		$result = ( wp_mail( cscf_PluginSettings::RecipientEmails(), cscf_PluginSettings::Subject(), stripslashes( $message ), $header ) );

--- a/src/class.cscf_pluginsettings.php
+++ b/src/class.cscf_pluginsettings.php
@@ -112,6 +112,7 @@ class cscf_PluginSettings
 
     }
 
+
     static
     function EmailToSender()
     {
@@ -143,7 +144,29 @@ class cscf_PluginSettings
 
     }
 
+
     static
+    function PhoneNumber()
+    {
+
+        $options = get_option(CSCF_OPTIONS_KEY);
+
+        return isset($options['phone-number']) ? true : false;
+
+    }
+
+	static
+    function PhoneNumberMandatory()
+    {
+
+        $options = get_option(CSCF_OPTIONS_KEY);
+
+        return isset($options['phone-number-mandatory']) ? true : false;
+
+    }
+
+
+	static
     function IsJetPackContactFormEnabled()
     {
         //check for jetpack plugin

--- a/src/class.cscf_settings.php
+++ b/src/class.cscf_settings.php
@@ -132,13 +132,13 @@ class cscf_settings {
 		), 'contact-form-settings', 'section_message', array(
 			'email-sender'
 		) );
-		add_settings_field( 'contact-consent', '<span style="color:red;">' . esc_html__( '*New*', 'clean-and-simple-contact-form-by-meg-nicholas' ) . '</span> ' . esc_html__( 'Add a consent checkbox :', 'clean-and-simple-contact-form-by-meg-nicholas' ), array(
+		add_settings_field( 'contact-consent', esc_html__( 'Add a consent checkbox :', 'clean-and-simple-contact-form-by-meg-nicholas' ), array(
 			$this,
 			'create_fields'
 		), 'contact-form-settings', 'section_message', array(
 			'contact-consent'
 		) );
-		add_settings_field( 'contact-consent-msg', '<span style="color:red;">' . esc_html__( '*New*', 'clean-and-simple-contact-form-by-meg-nicholas' ) . '</span> ' . esc_html__( 'Consent message :', 'clean-and-simple-contact-form-by-meg-nicholas' ), array(
+		add_settings_field( 'contact-consent-msg', esc_html__( 'Consent message :', 'clean-and-simple-contact-form-by-meg-nicholas' ), array(
 			$this,
 			'create_fields'
 		), 'contact-form-settings', 'section_message', array(

--- a/src/class.cscf_settings.php
+++ b/src/class.cscf_settings.php
@@ -39,7 +39,7 @@ class cscf_settings {
         <h2><?php esc_html_e( 'Clean and Simple Contact Form Settings', 'clean-and-simple-contact-form-by-meg-nicholas' ); ?></h2>
         <hr/>
         <div style="float:left;">
-            <p><?php esc_html_e( 'You are using version', 'clean-and-simple-contact-form-by-meg-nicholas' ); ?><?php echo esc_attr(CSCF_VERSION_NUM); ?></p>
+            <p><?php esc_html_e( 'You are using version', 'clean-and-simple-contact-form-by-meg-nicholas' ); ?> <?php echo esc_attr(CSCF_VERSION_NUM); ?></p>
 
             <p><?php esc_html_e( 'If you find this plugin useful please consider', 'clean-and-simple-contact-form-by-meg-nicholas' ); ?>
                 <a target="_blank"

--- a/src/class.cscf_settings.php
+++ b/src/class.cscf_settings.php
@@ -39,7 +39,7 @@ class cscf_settings {
         <h2><?php esc_html_e( 'Clean and Simple Contact Form Settings', 'clean-and-simple-contact-form-by-meg-nicholas' ); ?></h2>
         <hr/>
         <div style="float:left;">
-            <p><?php esc_html_e( 'You are using version', 'clean-and-simple-contact-form-by-meg-nicholas' ); ?><?php echo esc_attr(CSCF_VERSION_NUM); ?></p>
+            <p><?php esc_html_e( 'You are using version', 'clean-and-simple-contact-form-by-meg-nicholas' ); ?> <?php echo esc_attr(CSCF_VERSION_NUM); ?>.</p>
 
             <p><?php esc_html_e( 'If you find this plugin useful please consider', 'clean-and-simple-contact-form-by-meg-nicholas' ); ?>
                 <a target="_blank"
@@ -132,17 +132,29 @@ class cscf_settings {
 		), 'contact-form-settings', 'section_message', array(
 			'email-sender'
 		) );
-		add_settings_field( 'contact-consent', '<span style="color:red;">' . esc_html__( '*New*', 'clean-and-simple-contact-form-by-meg-nicholas' ) . '</span> ' . esc_html__( 'Add a consent checkbox :', 'clean-and-simple-contact-form-by-meg-nicholas' ), array(
+		add_settings_field( 'contact-consent', esc_html__( 'Add a consent checkbox :', 'clean-and-simple-contact-form-by-meg-nicholas' ), array(
 			$this,
 			'create_fields'
 		), 'contact-form-settings', 'section_message', array(
 			'contact-consent'
 		) );
-		add_settings_field( 'contact-consent-msg', '<span style="color:red;">' . esc_html__( '*New*', 'clean-and-simple-contact-form-by-meg-nicholas' ) . '</span> ' . esc_html__( 'Consent message :', 'clean-and-simple-contact-form-by-meg-nicholas' ), array(
+		add_settings_field( 'contact-consent-msg', esc_html__( 'Consent message :', 'clean-and-simple-contact-form-by-meg-nicholas' ), array(
 			$this,
 			'create_fields'
 		), 'contact-form-settings', 'section_message', array(
 			'contact-consent-msg'
+		) );
+		add_settings_field( 'phone-number', esc_html__( 'Add a phone number field :', 'clean-and-simple-contact-form-by-meg-nicholas' ), array(
+			$this,
+			'create_fields'
+		), 'contact-form-settings', 'section_message', array(
+			'phone-number'
+		) );
+		add_settings_field( 'phone-number-mandatory', esc_html__( 'Phone number is mandatory :', 'clean-and-simple-contact-form-by-meg-nicholas' ), array(
+			$this,
+			'create_fields'
+		), 'contact-form-settings', 'section_message', array(
+			'phone-number-mandatory'
 		) );
 		add_settings_field( 'override-from', esc_html__( 'Override \'From\' Address :', 'clean-and-simple-contact-form-by-meg-nicholas' ), array(
 			$this,
@@ -359,6 +371,16 @@ class cscf_settings {
 				?><input type="text" size="60" id="contact-consent-msg"
                          name="<?php echo esc_attr( CSCF_OPTIONS_KEY ); ?>[contact-consent-msg]"
                          value="<?php echo esc_attr( cscf_PluginSettings::ContactConsentMsg() ); ?>"><?php
+				break;
+			case 'phone-number':
+				$checked = cscf_PluginSettings::PhoneNumber() == true ? "checked" : "";
+				?><input type="checkbox" <?php echo esc_attr( $checked ); ?>  id="phone-number"
+                         name="<?php echo esc_attr( CSCF_OPTIONS_KEY ); ?>[phone-number]"><?php
+				break;
+			case 'phone-number-mandatory':
+				$checked = cscf_PluginSettings::PhoneNumberMandatory() == true ? "checked" : "";
+				?><input type="checkbox" <?php echo esc_attr( $checked ); ?>  id="phone-number-mandatory"
+                         name="<?php echo esc_attr( CSCF_OPTIONS_KEY ); ?>[phone-number-mandatory]"><?php
 				break;
 			case 'from-email':
 				$disabled = cscf_PluginSettings::OverrideFrom() === false ? "readonly" : "";

--- a/src/clean-and-simple-contact-form-by-meg-nicholas.php
+++ b/src/clean-and-simple-contact-form-by-meg-nicholas.php
@@ -7,7 +7,7 @@
 Plugin Name: Clean and Simple Contact Form
 Plugin URI: https://fullworks.net/productsclean-and-simple-contact-form
 Description: A clean and simple contact form with Google reCAPTCHA and Twitter Bootstrap markup.
-Version: 4.7.5
+Version: 4.7.6
 Author: Fullworks
 Author URI: https://fullworks.net
 License: GPLv2 or later
@@ -71,7 +71,7 @@ if ( ! defined( 'CSCF_VERSION_KEY' ) ) {
 }
 
 if ( ! defined( 'CSCF_VERSION_NUM' ) ) {
-	define( 'CSCF_VERSION_NUM', '4.7.2' );
+	define( 'CSCF_VERSION_NUM', '4.7.6' );
 }
 
 if ( ! defined( 'CSCF_OPTIONS_KEY' ) ) {

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -4,9 +4,9 @@ License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl.html
 Tags: simple, contact, form, contact button, contact form, contact form plugin, akismet, contacts, contacts form plugin, contact me, feedback form, bootstrap, twitter, google, reCAPTCHA, ajax, secure
 Requires at least: 4.6
-Tested up to: 5.7
+Tested up to: 5.7.2
 Requires PHP: 5.6
-Stable tag: 4.7.5
+Stable tag: 4.7.6
 
 A clean and simple AJAX contact form with Google reCAPTCHA, Twitter Bootstrap markup and Akismet spam filtering.
 
@@ -197,6 +197,12 @@ the reCAPTCHA for the contact form will be displayed correctly but not in the co
 The comments form will never validate due to no supplied reCAPTCHA code.
 
 == Changelog ==
+= 4.7.6 =
+* Introduced optional input field for phone number
+* Exclude consent message from email if disabled
+* Fixed spacing and line breaks in email template
+* Fixed minor issues on settings page
+
 = 4.7.5 =
 * correct a couple of text domain issues introduced at 4.7.2
 

--- a/src/views/contact-form.view.php
+++ b/src/views/contact-form.view.php
@@ -106,6 +106,33 @@
                 </div>
 			<?php } ?>
 
+			<?php if ( cscf_PluginSettings::PhoneNumber() ) { ?>
+                <!-- telephone number -->
+                <div class="control-group form-group<?php if ( isset( $contact->Errors['phone-number'] ) ) {
+					echo ' error has-error';
+				} ?>">
+                    <label for="cscf_phone-number"><?php esc_html_e( 'Phone Number:', 'clean-and-simple-contact-form-by-meg-nicholas' ); ?></label>
+                    <div class="<?php echo ( true === cscf_PluginSettings::InputIcons() ) ? 'input-group' : ''; ?>">
+						<?php if ( cscf_PluginSettings::InputIcons() == true ) { ?>
+                            <span class="input-group-addon"><span class="glyphicon glyphicon-phone-alt"></span></span>
+						<?php } ?>
+                        <input class="form-control input-xlarge"
+                               data-rule-required="<?php echo ( true === cscf_PluginSettings::PhoneNumberMandatory() ) ? 'true' : 'false'; ?>"
+							   data-msg-required="<?php esc_html_e( 'Please give your phone number.', 'clean-and-simple-contact-form-by-meg-nicholas' ); ?>"
+							   type="text" id="cscf_phone-number" name="cscf[phone-number]"
+                               value="<?php echo esc_attr( $contact->PhoneNumber ); ?>"
+                               placeholder="<?php esc_html_e( 'Your Phone Number', 'clean-and-simple-contact-form-by-meg-nicholas' ); ?>"
+                        />
+                    </div>
+                    <span for="cscf_phone-number" class="help-inline help-block error"
+                          style="display:<?php echo isset( $contact->Errors['phone-number'] ) ? 'block' : 'none'; ?>;">
+                    <?php if ( isset( $contact->Errors['phone-number'] ) ) {
+	                    echo esc_attr( $contact->Errors['phone-number'] );
+                    } ?>
+                </span>
+                </div>
+			<?php } ?>
+
 
             <!-- message -->
             <div class="control-group form-group<?php if ( isset( $contact->Errors['message'] ) ) {
@@ -161,13 +188,13 @@
                 <div class="control-group form-group<?php if ( isset( $contact->Errors['contact-consent'] ) ) {
 					echo ' error has-error';
 				} ?>">
-                    <label for="cscf_contact-consent"><?php echo esc_html( cscf_PluginSettings::ContactConsentMsg() ); ?>
-                        :</label>
+                    <label for="cscf_contact-consent"><?php echo esc_html( cscf_PluginSettings::ContactConsentMsg() ); ?>:</label>
                     <div class="<?php echo ( cscf_PluginSettings::InputIcons() ) ? "input-group" : ""; ?>">
 						<?php if ( cscf_PluginSettings::InputIcons() == true ) { ?>
                             <span class="input-group-addon"><span class="glyphicon glyphicon-comment"></span></span>
 						<?php } ?>
-                        <input data-rule-required="true"
+                        <input class="form-control input-xlarge"
+							   data-rule-required="true"
                                data-msg-required="<?php esc_html_e( 'Please give your consent.', 'clean-and-simple-contact-form-by-meg-nicholas' ); ?>"
 							<?php echo ( true === $contact->ContactConsent ) ? 'checked' : ''; ?> type="checkbox"
                                id="cscf_contact-consent"


### PR DESCRIPTION
Refactored email template to move colon from translation to code. Fixes #4.

This will add blank space after 'Email' label that was missing in (German) translation.

Translations on translate.wordpress.org need to be updated, though (remove colon and space).